### PR TITLE
Hide arrow icon on mobile in FigmaTrainingCard

### DIFF
--- a/src/components/FigmaTrainingCard.tsx
+++ b/src/components/FigmaTrainingCard.tsx
@@ -11,7 +11,7 @@ const FigmaTrainingCard: React.FC = () => {
           <h5>For Designers, Students, and PMs</h5>
           <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.4em' }}>
             Book a Figma training session today
-            <ArrowRight size={24} weight="regular" />
+            <ArrowRight size={24} weight="regular" className="arrow-icon" />
           </h3>
           <p>I've conducted more than 100+ Figma training at top companies and institutes. Book a 1:1 session or a corporate workshop.</p>
         </div>

--- a/src/styles/FigmaTrainingCard.scss
+++ b/src/styles/FigmaTrainingCard.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 1em;
+  gap: 1.5em;
   padding: 1.5em;
   border-radius: 0.75em;
   background: var(--bg-color-high);
@@ -152,7 +152,7 @@
   @media (max-width: 600px) {
     flex-direction: row;
     align-items: flex-start;
-    gap: 0.7em;
+    gap: 1em;
     padding: 1em;
 
     .figma-training-image-stack {
@@ -168,13 +168,11 @@
       }
     }
     .figma-training-content {
-      gap: 0.7em;
-      h3 {
-        font-size: 1.1em;
-      }
-      p {
-        font-size: 0.98em;
-      }
+      gap: 0.2em;
+    
+    }
+    .arrow-icon {
+      display: none;
     }
   }
 } 


### PR DESCRIPTION
Added a class to the ArrowRight icon and updated SCSS to hide the arrow on screens smaller than 600px. Also adjusted spacing and font sizes for better mobile layout.